### PR TITLE
Merge the remainder of Jeff Dairiki's "ipv6" branch

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,12 @@ Next release
 
  - fix tests for API change in pydns >= 2.3.6
 
+ - It is no longer an error to request binding to a particular
+   address/port more than once. (The subsequent requests are simply
+   ignored.) (This avoids confusion on certain systems/configurations
+   where gethostbyname("localhost") can return 127.0.0.1 multiple
+   times.)
+
 0.997a (23 Jul 2013)
 
  - minor fixes/changes in packaging, no code changes.

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,13 @@
 This file describes user-visible changes in rbldnsd.
 Newer news is at the top.
 
+Next release
+
+ - fix tests for systems without ipv6 support, or when ipv6 is
+   disabled in rbldnsd at compile-time
+
+ - fix tests for API change in pydns >= 2.3.6
+
 0.997a (23 Jul 2013)
 
  - minor fixes/changes in packaging, no code changes.

--- a/rbldnsd.py
+++ b/rbldnsd.py
@@ -2,6 +2,7 @@
 
 
 """
+import errno
 from itertools import count
 import subprocess
 from tempfile import NamedTemporaryFile, TemporaryFile
@@ -12,6 +13,14 @@ try:
     import DNS
 except ImportError:
     raise RuntimeError("The pydns library is not installed")
+try:
+    from DNS import SocketError as DNS_SocketError
+except ImportError:
+    class DNS_SocketError(Exception):
+        """ Dummy, never raised.
+
+        (Older versions of pydns before 2.3.6 do not raise SocketError.)
+        """
 
 DUMMY_ZONE_HEADER = """
 $SOA 0 example.org. hostmaster.example.com. 0 1h 1h 2d 1h
@@ -123,12 +132,17 @@ class Rbldnsd(object):
                 break
             except QueryRefused:
                 break
+            except DNS_SocketError as ex:
+                # pydns >= 2.3.6
+                wrapped_error = ex.args[0]
+                if wrapped_error.errno != errno.ECONNREFUSED:
+                    raise
             except DNS.DNSError as ex:
+                # pydns < 2.3.6
                 if str(ex) != 'no working nameservers found':
                     raise
-                elif retry > 10:
-                    raise DaemonError(
-                        "rbldnsd does not seem to be responding")
+            if retry > 10:
+                raise DaemonError("rbldnsd does not seem to be responding")
             time.sleep(0.1)
 
     def _stop_daemon(self):

--- a/rbldnsd.py
+++ b/rbldnsd.py
@@ -150,6 +150,22 @@ class Rbldnsd(object):
             raise DaemonError("rbldnsd exited with code %d"
                               % daemon.returncode)
 
+    @property
+    def no_ipv6(self):
+        """ Was rbldnsd compiled with -DNO_IPv6?
+        """
+        # If rbldnsd was compiled with -DNO_IPv6, the (therefore
+        # unsupported) '-6' command-line switch will not be described
+        # in the help message
+        cmd = [self.daemon_bin, '-h']
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        help_message = proc.stdout.readlines()
+        if proc.wait() != 0:
+            raise subprocess.CalledProcessError(proc.returncode, cmd)
+        return not any(line.lstrip().startswith('-6 ')
+                       for line in help_message)
+
+
 class TestRbldnsd(unittest.TestCase):
     def test(self):
         rbldnsd = Rbldnsd()

--- a/rbldnsd.py
+++ b/rbldnsd.py
@@ -113,7 +113,6 @@ class Rbldnsd(object):
                                                  stderr=self.stderr)
 
         # wait for rbldnsd to start responding
-        time.sleep(0.1)
         for retry in count():
             if daemon.poll() is not None:
                 raise DaemonError(
@@ -127,9 +126,10 @@ class Rbldnsd(object):
             except DNS.DNSError as ex:
                 if str(ex) != 'no working nameservers found':
                     raise
-                elif retries > 10:
+                elif retry > 10:
                     raise DaemonError(
                         "rbldnsd does not seem to be responding")
+            time.sleep(0.1)
 
     def _stop_daemon(self):
         daemon = self._daemon

--- a/test_acl.py
+++ b/test_acl.py
@@ -1,5 +1,8 @@
 """ Tests for the acl dataset
 """
+from functools import wraps
+import socket
+import sys
 from tempfile import NamedTemporaryFile
 import unittest
 
@@ -8,6 +11,30 @@ from rbldnsd import ZoneFile, Rbldnsd, QueryRefused
 __all__ = [
     'TestAclDataset',
     ]
+
+try:
+    from unittest import skipIf
+except ImportError:
+    # hokey replacement (for python <= 2.6)
+    def skipIf(condition, reason):
+        if condition:
+            def decorate(f):
+                @wraps(f)
+                def skipped(*args, **kw):
+                    sys.stderr.write("skipped test: %s " % reason)
+                return skipped
+            return decorate
+        else:
+            return lambda f: f
+
+try:
+    # check for ipv6 support in python, kernel, libc
+    socket.socket(socket.AF_INET6, socket.SOCK_DGRAM).close()
+except (socket.error, AttributeError):
+    no_ipv6 = True
+else:
+    # check for ipv6 support in rbldnsd
+    no_ipv6 = Rbldnsd().no_ipv6
 
 def daemon(acl, addr='localhost'):
     """ Create an Rbldnsd instance with given ACL
@@ -33,11 +60,13 @@ class TestAclDataset(unittest.TestCase):
                     addr='127.0.0.1') as dnsd:
             self.assertEqual(dnsd.query('test.example.com'), 'Success')
 
+    @skipIf(no_ipv6, "IPv6 unsupported")
     def test_refuse_ipv6(self):
         with daemon(acl=["::1 :refuse"],
                     addr='::1') as dnsd:
             self.assertRaises(QueryRefused, dnsd.query, 'test.example.com')
 
+    @skipIf(no_ipv6, "IPv6 unsupported")
     def test_pass_ipv6(self):
         with daemon(acl=[ "0/0 :refuse",
                           "0::1 :pass" ],

--- a/test_ip4trie.py
+++ b/test_ip4trie.py
@@ -9,7 +9,7 @@ __all__ = [
     ]
 
 def ip4trie(zone_data):
-    """ Run rbldnsd with an ip6trie dataset
+    """ Run rbldnsd with an ip4trie dataset
     """
     dnsd = Rbldnsd()
     dnsd.add_dataset('ip4trie', ZoneFile(zone_data))

--- a/test_ip6trie.py
+++ b/test_ip6trie.py
@@ -15,21 +15,42 @@ def ip6trie(zone_data):
     dnsd.add_dataset('ip6trie', ZoneFile(zone_data))
     return dnsd
 
-def rfc3152(ip6addr, domain='example.com'):
-    from socket import inet_pton, AF_INET6
-    from struct import unpack
-
-    bytes = unpack("16B", inet_pton(AF_INET6, ip6addr))
-    nibbles = '.'.join("%x.%x" % (byte & 0xf, (byte >> 4) & 0xf)
-                       for byte in reversed(bytes))
-    return "%s.%s" % (nibbles, domain)
-
 class TestIp6TrieDataset(unittest.TestCase):
     def test_exclusion(self):
         with ip6trie(["dead::/16 listed",
                       "!dead::beef"]) as dnsd:
             self.assertEqual(dnsd.query(rfc3152("dead::beef")), None)
             self.assertEqual(dnsd.query(rfc3152("dead::beee")), "listed")
+
+
+def rfc3152(ip6addr, domain='example.com'):
+    return "%s.%s" % ('.'.join(reversed(_to_nibbles(ip6addr))), domain)
+
+def _to_nibbles(ip6addr):
+    """ Convert ip6 address (in rfc4291 notation) to a sequence of nibbles
+
+    NB: We avoid the use of socket.inet_pton(AF_INET6, ip6addr) here
+    because it fails (with 'error: can't use AF_INET6, IPv6 is
+    disabled') when python has been compiled without IPv6 support. See
+    http://www.corpit.ru/pipermail/rbldnsd/2013q3/001181.html
+
+    """
+    def _split_words(addr):
+        return [ int(w, 16) for w in addr.split(':') ] if addr else []
+
+    if '::' in ip6addr:
+        head, tail = [ _split_words(s) for s in ip6addr.split('::', 1) ]
+        nzeros = 8 - len(head) - len(tail)
+        assert nzeros >= 0
+        words = head + [ 0 ] * nzeros + tail
+    else:
+        words = _split_words(ip6addr)
+
+    assert len(words) == 8
+    for word in words:
+        assert 0 <= word <= 0xffff
+
+    return ''.join("%04x" % word for word in words)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This would merge the remainder of the ipv6 branch from @dairiki. There was a tiny conflict in the `NEWS` file, so I commented on the changes in my merge commit. We've been carrying this as a patch for over... two years now, on Gentoo, where people regularly build python sans ipv6 support. No problems have been reported.

In the interest of full disclosure, the additional changes were rejected by Michael Tokarev. However, if you refer back to the mailing list thread, I got the impression that the rejection was of the "it's not worth the trouble" sort. So, if you are willing to review the additional commits, that concern may be abated =)

The `gethostbyname()` thing is a general "papercut" fix that applies even outside of the test suite.