### PR TITLE
Add ability for DSO extension to support new dataset type handling methods

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -63,7 +63,7 @@ RBLDNSD_SRCS = rbldnsd.c rbldnsd_zones.c rbldnsd_packet.c \
   rbldnsd_ip4set.c rbldnsd_ip4tset.c rbldnsd_ip4trie.c \
   rbldnsd_ip6tset.c rbldnsd_ip6trie.c rbldnsd_dnset.c \
   rbldnsd_generic.c rbldnsd_combined.c rbldnsd_acl.c \
-  rbldnsd_util.c
+  rbldnsd_extension.c rbldnsd_util.c
 RBLDNSD_HDRS = rbldnsd.h
 RBLDNSD_OBJS = $(RBLDNSD_SRCS:.c=.o) lib$(NAME).a
 

--- a/rbldnsd.c
+++ b/rbldnsd.c
@@ -498,7 +498,7 @@ static void init(int argc, char **argv) {
   const struct zone *z;
 #ifndef NO_DSO
   char *ext = NULL;
-  int  (*extinit)   (const char *arg, struct zone *zonelist) = NULL;
+  int (*extinit)(const char *arg, struct zone *zonelist) = NULL;
   extension_loaded = 0;
 #endif
 

--- a/rbldnsd.h
+++ b/rbldnsd.h
@@ -37,7 +37,6 @@ struct dataset;
 struct dsdata;
 struct dsctx;
 struct sockaddr;
-struct istream;
 
 struct dnspacket {		/* private structure */
   unsigned char p_buf[DNS_EDNS0_MAXPACKET]; /* packet buffer */

--- a/rbldnsd_extension.c
+++ b/rbldnsd_extension.c
@@ -1,0 +1,99 @@
+#include <stdio.h>
+#include "rbldnsd.h"
+#include <syslog.h>
+
+#ifndef NO_DSO
+
+extern int extension_loaded;
+extern char *extarg;
+
+struct dsdata {
+  /* correlates to any -X arguments given at start of program */
+  char *extargs;
+
+  /* correlates to dataset file */
+  char *dataset_file;
+};
+
+definedstype(extension, DSTF_IP4REV, "extension that handles responses to IPv4 lookups");
+
+/*
+ * extension 'reset' handler wrapper.
+ *
+ * This is called at start of program and intended to flush any memory
+ * the dataset is currently using, then load up fresh data.  Also called
+ * any time a reload / refresh is enacted by the parent daemon.
+ *
+ * NOTE: the safety check 'extension_loaded' will implicitly break any 'dump'
+ *       calls - this is because extensions are loaded *after* dump flag
+ *       processing takes place.
+ */
+static void ds_extension_reset(struct dsdata *dsd, int freeall)
+{
+  if (!extension_loaded)
+    error(0, "critical error - extension reset called with no extension loaded");
+
+  /* initialize the dataset 'extarg' as required */
+  if (!dsd->extargs && extarg)
+    dsd->extargs = extarg;
+
+  if (extreset)
+    extreset(dsd, freeall);
+}
+
+static void ds_extension_start(struct dataset *ds)
+{
+  if (!extension_loaded)
+    error(0, "critical error - extension start called with no extension loaded");
+
+  if (extstart)
+    extstart(ds);
+}
+
+static int ds_extension_line(struct dataset *ds, char *s, struct dsctx *dsc)
+{
+  if (!extension_loaded)
+    error(0, "critical error - extension line called with no extension loaded");
+
+  if (extline)
+    return extline(ds, s, dsc);
+
+  return 1;
+}
+
+static void ds_extension_finish(struct dataset *ds, struct dsctx *dsc)
+{
+  if (!extension_loaded)
+    error(0, "critical error - extension finish called with no extension loaded");
+
+  if (extfinish)
+    extfinish(ds, dsc);
+}
+
+static int ds_extension_query(
+              const struct dataset *ds,
+              const struct dnsqinfo *qi,
+              struct dnspacket *pkt)
+{
+  if (!extension_loaded)
+    error(0, "critical error - extension query called with no extension loaded");
+
+  if (!extquery)
+    error(0, "critical error - extension query called with no query function defined");
+
+  return extquery(ds, qi, pkt);
+}
+
+#ifndef NO_MASTER_DUMP
+static void ds_extension_dump(
+                  const struct dataset *ds,
+                  const unsigned char *odn,
+                  FILE *f)
+{
+  if (extdump)
+    extdump(ds, odn, f);
+}
+
+#endif
+
+#endif

--- a/rbldnsd_zones.c
+++ b/rbldnsd_zones.c
@@ -385,6 +385,16 @@ int loaddataset(struct dataset *ds) {
   memset(&dsc, 0, sizeof(dsc));
   dsc.dsc_ds = ds;
 
+#ifndef NO_DSO
+  if (  extloaddataset
+     && ds
+     && ds->ds_type
+     && ds->ds_type->dst_name
+     && strcmp(ds->ds_type->dst_name, "extension") == 0) {
+    return extloaddataset(ds);
+  }
+#endif
+
   for(dsf = ds->ds_dsf; dsf; dsf = dsf->dsf_next) {
     dsc.dsc_fname = dsf->dsf_name;
     fd = open(dsf->dsf_name, O_RDONLY);


### PR DESCRIPTION
The current methods for providing dataset types (eg: source data formats) for rbldnsd is largely limited to modifying the core code at time of compile.  The original concept of providing support for DSO extensions allowed one to 'initialize' a DSO through an external shared object, and theoretically define 'hook' functions that are called at varying points in dataset processing.

This modification extends what the DSO extensions are capable of by adding an embedded dataset type for 'extensions', and supplying a framework of extension functions that can be defined within said extension for the purposes of providing a new dataset type format / data source.