### PR TITLE
configure,rbldnsd.c: include <poll.h> instead of <sys/poll.h>.

### DIFF
--- a/configure
+++ b/configure
@@ -222,7 +222,7 @@ fi
 
 if ac_link_v "for poll()" <<EOF
 #include <sys/types.h>
-#include <sys/poll.h>
+#include <poll.h>
 int main() {
   struct pollfd pfd[2];
   return poll(pfd, 2, 10);

--- a/rbldnsd.c
+++ b/rbldnsd.c
@@ -35,7 +35,7 @@
 # include <sys/select.h>
 #endif
 #ifndef NO_POLL
-# include <sys/poll.h>
+# include <poll.h>
 #endif
 #ifndef NO_MEMINFO
 # include <malloc.h>


### PR DESCRIPTION
As far back as 1997, the Single UNIX Specification (that later became POSIX) has said that <poll.h> is the file that provides poll() and friends:

  https://pubs.opengroup.org/onlinepubs/7908799/xsh/poll.h.html

Most implementations also support the old <sys/poll.h>, but musl, for example, raises a warning about its usage:

  https://git.musl-libc.org/cgit/musl/tree/include/sys/poll.h

This commit updates <sys/poll.h> to <poll.h> in two places.

Closes: https://github.com/spamhaus/rbldnsd/issues/25