### PR TITLE
configure,rbldnsd.c: replace mallinfo() with mallinfo2()

### DIFF
--- a/configure
+++ b/configure
@@ -206,12 +206,12 @@ else
 fi
 fi # enable_ipv6?
 
-if ac_link_v "for mallinfo()" <<EOF
+if ac_link_v "for mallinfo2()" <<EOF
 #include <sys/types.h>
 #include <stdlib.h>
 #include <malloc.h>
 int main() {
-  struct mallinfo mi = mallinfo();
+  struct mallinfo2 mi = mallinfo2();
   return 0;
 }
 EOF

--- a/rbldnsd.c
+++ b/rbldnsd.c
@@ -1187,10 +1187,10 @@ static int do_reload(int do_fork) {
 #endif /* NO_TIMES */
 #ifndef NO_MEMINFO
   {
-    struct mallinfo mi = mallinfo();
+    struct mallinfo2 mi = mallinfo2();
 # define kb(x) ((mi.x + 512)>>10)
     ip += ssprintf(ibuf + ip, sizeof(ibuf) - ip,
-          ", mem arena=%d free=%d mmap=%d Kb",
+          ", mem arena=%zd free=%zd mmap=%zd Kb",
           kb(arena), kb(fordblks), kb(hblkhd));
 # undef kb
   }


### PR DESCRIPTION
The `mallinfo()` function from `malloc.h` is deprecated, and has been replaced by `mallinfo2()`. Additionally, the `mallinfo` struct that it returns has been replaced by a `mallinfo2` struct. The only difference between the two is that the newer struct contains members of type `size_t` rather than `int`, which proved to be too small (leading to overflows).

The call to `ssprintf()` that prints this information has been updated to use the **z** length modifier, which is C99, but which is probably safe by now. Other C99 features are already being used by rbldnsd.